### PR TITLE
Fix gallery resize overflow-x

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -261,6 +261,12 @@ hr.style2 {
   background-repeat: no-repeat;
   background-position: 85% 90px;
 }
+#gallery-content
+{
+  padding-left: 18px;
+  padding-right: 18px;
+  background:#111;
+}
 .gallery
 {
   width: 25%;

--- a/index.php
+++ b/index.php
@@ -284,7 +284,7 @@
 
   <a id="gallery" class="anchor"></a>
   
-  <div>
+  <div id="gallery-content">
 	<iframe class="gallery" src="https://www.youtube.com/embed/6G3_fsFAiSM" frameborder="0" allowfullscreen onClick="ga('send', 'event', 'insite', 'video_1', '<?php echo $lang['SITE_LANG']; ?>');"></iframe>
 	<iframe class="gallery" src="https://www.youtube.com/embed/vnoVmUTamXM" frameborder="0" allowfullscreen onClick="ga('send', 'event', 'insite', 'video_2', '<?php echo $lang['SITE_LANG']; ?>');"></iframe>	
     <iframe class="gallery" src="https://www.youtube.com/embed/SS_RRuNCe6Y" frameborder="0" allowfullscreen onClick="ga('send', 'event', 'insite', 'video_3', '<?php echo $lang['SITE_LANG']; ?>');"></iframe>


### PR DESCRIPTION
I noticed that when you go hover an element in the gallery, the images which are on the right resizing get the page larger than normal and the overflow-x appear. In this way, you see a vertical white line.
I fixed it adding a simple padding backgrounded with the same color of whole the site. In this way, when the images get resized they doesn't break the border of the page.